### PR TITLE
WIP: response parameter deserialization fixes

### DIFF
--- a/Extrasolar/demo/Extrasolar.Demo.Loopback/HelloService.cs
+++ b/Extrasolar/demo/Extrasolar.Demo.Loopback/HelloService.cs
@@ -1,9 +1,17 @@
-﻿using System;
-
-namespace Extrasolar.Demo.Loopback
+﻿namespace Extrasolar.Demo.Loopback
 {
     public class HelloService : IHelloService
     {
+        public int Add(int a, int b)
+        {
+            return a + b;
+        }
+
+        public bool IsSkyBlue()
+        {
+            return true; // actually: usually :P :D
+        }
+
         public string SayHello() => "Hello, World through RPC fluent API.";
     }
 }

--- a/Extrasolar/demo/Extrasolar.Demo.Loopback/IHelloService.cs
+++ b/Extrasolar/demo/Extrasolar.Demo.Loopback/IHelloService.cs
@@ -3,5 +3,7 @@
     public interface IHelloService
     {
         string SayHello();
+        bool IsSkyBlue();
+        int Add(int a, int b);
     }
 }

--- a/Extrasolar/demo/Extrasolar.Demo.Loopback/RpcCallerDemo.cs
+++ b/Extrasolar/demo/Extrasolar.Demo.Loopback/RpcCallerDemo.cs
@@ -39,8 +39,10 @@ namespace Extrasolar.Demo.Loopback
             //var result = await caller.CallByNameAsync<string>(nameof(IHelloServer.SayHello));
             _barrier.SignalAndWait();
             var client = caller.CreateClient();
-            var result = client.SayHello();
-            Console.WriteLine($"Sent command from client. Server responded {result}");
+            var helloResult = client.SayHello();
+            Console.WriteLine($"Sent command from client. Server responded {helloResult}");
+            Console.WriteLine($"Is the sky blue?: {client.IsSkyBlue()}");
+            Console.WriteLine($"1 + 3 is: {client.Add(1, 3)}");
             await Task.Delay(0);
         }
     }

--- a/Extrasolar/src/Extrasolar/Rpc/RpcService.cs
+++ b/Extrasolar/src/Extrasolar/Rpc/RpcService.cs
@@ -86,9 +86,22 @@ namespace Extrasolar.Rpc
                     }
                 }
             }
+            var selectedMethod = targetMethodCandidates.First();
+            // Normalize arguments
+            var parameterTypes = selectedMethod.GetParameters().Select(x => x.ParameterType).ToArray();
+            for (int i = 0; i < parameterTypes.Length; i++)
+            {
+                var paramType = parameterTypes[i];
+                var callParam = callArgs[i];
+                if (!paramType.IsInstanceOfType(callParam))
+                {
+                    // If the call parameter isn't an instance, cast
+                    callArgs[i] = Convert.ChangeType(callParam, paramType);
+                }
+            }
             try
             {
-                var result = targetMethodCandidates.First().Invoke(ServiceImplementation, callArgs.ToArray());
+                var result = selectedMethod.Invoke(ServiceImplementation, callArgs.ToArray());
                 var resultJObject = JToken.FromObject(result);
                 return new ResultResponse(request, resultJObject);
             }


### PR DESCRIPTION
Automatically cast types:

Previously, since `Json.NET` deserializes integers to `Int64`, errors occur because a method expected an `Int32`, for instance. With this update, all parameters will be checked and automatically casted if they do not match.